### PR TITLE
Increase Symfony dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
     "php": ">=7.1",
     "ext-json": "*",
     "contao/core-bundle":"~4.4",
-    "symfony/yaml": "^3.3 || ^4.2"
+    "symfony/yaml": "^3.3 || ^4.2 || ^5.2"
   },
   "autoload": {
     "psr-4": {


### PR DESCRIPTION
The `symfony/yaml` dependency can be safely increased to Symfony 5. I tested it and there were no issues. This makes it easier to install this extension in a fresh Contao 4.11 setup.